### PR TITLE
Use the latest `ronin` syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@react-aria/ssr": "^3.9.2",
     "@react-aria/textfield": "^3.14.3",
     "@react-email/components": "0.0.16",
-    "@ronin/casper": "0.0.0-3415317874336",
+    "@ronin/casper": "0.0.0-3415827858543",
     "@t3-oss/env-nextjs": "^0.9.2",
     "@tailwindcss/typography": "^0.5.12",
     "@tanstack/react-query": "^5.29.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "rehype-slug": "^5.1.0",
     "remark-gfm": "^3.0.1",
     "resend": "^3.2.0",
-    "ronin": "2.1.0",
+    "ronin": "2.1.1",
     "rss": "^1.2.2",
     "server-only": "^0.0.1",
     "sharp": "^0.33.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 0.0.16
         version: 0.0.16(@types/react@18.2.79)(react@18.2.0)
       '@ronin/casper':
-        specifier: 0.0.0-3415317874336
-        version: 0.0.0-3415317874336
+        specifier: 0.0.0-3415827858543
+        version: 0.0.0-3415827858543
       '@t3-oss/env-nextjs':
         specifier: ^0.9.2
         version: 0.9.2(typescript@5.4.5)(zod@3.22.5)
@@ -1345,8 +1345,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
 
-  '@ronin/casper@0.0.0-3415317874336':
-    resolution: {tarball: https://ronin.supply/@ronin/casper/-/casper-0.0.0-3415317874336.tar.gz}
+  '@ronin/casper@0.0.0-3415827858543':
+    resolution: {tarball: https://ronin.supply/@ronin/casper/-/casper-0.0.0-3415827858543.tar.gz}
 
   '@rushstack/eslint-patch@1.3.3':
     resolution: {integrity: sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw==}
@@ -5806,7 +5806,7 @@ snapshots:
       '@react-types/shared': 3.22.1(react@18.2.0)
       react: 18.2.0
 
-  '@ronin/casper@0.0.0-3415317874336': {}
+  '@ronin/casper@0.0.0-3415827858543': {}
 
   '@rushstack/eslint-patch@1.3.3': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,8 +135,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
       ronin:
-        specifier: 2.1.0
-        version: 2.1.0
+        specifier: 2.1.1
+        version: 2.1.1
       rss:
         specifier: ^1.2.2
         version: 1.2.2
@@ -4033,8 +4033,8 @@ packages:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
 
-  ronin@2.1.0:
-    resolution: {integrity: sha512-/FaCB/Lz7Fnv2iBnM66RNNgodL0mWEm4ZQ3yCAqsype3Mu5bAruumll5lFTJVFmJL9g4Xhm7eKPD/0XH02R3/g==}
+  ronin@2.1.1:
+    resolution: {integrity: sha512-AVLbum97bJ2VP1f+aOv7DRMRKIDo6lpluSeyJdM+I/RgLy6ZTwsDQUlozk3UiIOptH+dFwPIHZDNHs3+9JSv3Q==}
     engines: {node: '>=18.17.0'}
 
   rss@1.2.2:
@@ -9368,7 +9368,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  ronin@2.1.0: {}
+  ronin@2.1.1: {}
 
   rss@1.2.2:
     dependencies:

--- a/src/app/api/gallery/utils.ts
+++ b/src/app/api/gallery/utils.ts
@@ -3,12 +3,12 @@ import { get } from "ronin";
 export type GetGalleryImagesQuery = Awaited<ReturnType<typeof getGalleryImagesServer>>;
 export async function getGalleryImagesServer(after?: string | null) {
   const data = await get.galleryImages({
-    limitedTo: 9,
     // eslint-disable-next-line eqeqeq
     after: after != null ? after : undefined,
     orderedBy: {
       descending: ["ronin.createdAt"],
     },
+    limitedTo: 9,
   });
 
   return { data, moreAfter: data.moreAfter };

--- a/src/app/gallery/@modal/(..)photo/[id]/page.tsx
+++ b/src/app/gallery/@modal/(..)photo/[id]/page.tsx
@@ -8,7 +8,7 @@ interface ImageModalPageProps {
 }
 
 export default async function ImageModalPage({ params }: ImageModalPageProps) {
-  const image = await get.galleryImage.where.id.is(params.id);
+  const image = await get.galleryImage.with.id(params.id);
 
   if (!image) {
     return null;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,8 +12,8 @@ async function fetchHomePageData() {
   const [backpack, featuredProjects] = await batch(() => [
     get.mySkills.orderedBy.ascending(["ronin.createdAt"]),
     get.projects({
+      with: { isFeatured: true },
       orderedBy: { ascending: ["featuredPosition"] },
-      where: { isFeatured: { is: true } },
     }),
   ]);
 

--- a/src/app/photo/[id]/page.tsx
+++ b/src/app/photo/[id]/page.tsx
@@ -9,7 +9,7 @@ interface ImageModalPageProps {
 }
 
 export async function generateMetadata(props: ImageModalPageProps): Promise<Metadata> {
-  const image = await get.galleryImage.where.id.is(props.params.id);
+  const image = await get.galleryImage.with.id(props.params.id);
 
   if (!image) {
     return {};
@@ -45,7 +45,7 @@ export async function generateMetadata(props: ImageModalPageProps): Promise<Meta
 }
 
 export default async function ImageModalPage(props: ImageModalPageProps) {
-  const image = await get.galleryImage.where.id.is(props.params.id);
+  const image = await get.galleryImage.with.id(props.params.id);
 
   if (!image) {
     return null;

--- a/src/app/project/[slug]/page.tsx
+++ b/src/app/project/[slug]/page.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata({ params }: ProjectSlugPageProps) {
 }
 
 async function getProjectInformationFromRONIN(slug: string) {
-  const project = await get.project.where.slug.is(slug);
+  const project = await get.project.with.slug(slug);
 
   return project;
 }


### PR DESCRIPTION
In the latest `ronin` syntax, the `where` instruction was placed in favour of `with`, a much simpler and shorter syntax to work with.