### PR TITLE
Update images hostname for RONIN

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
   images: {
     formats: ["image/avif", "image/webp"],
     remotePatterns: [
-      { hostname: "media.ronin.co", protocol: "https" },
+      { hostname: "storage.ronin.co", protocol: "https" },
       { hostname: "avatars.githubusercontent.com", protocol: "https" },
       { hostname: "raw.githubusercontent.com", protocol: "https" },
     ],


### PR DESCRIPTION
Due to the recent improvements in the RONIN blob storage, we've depricated `media.ronin.co` as the hostname for images in favor of `storage.ronin.co`.