### PR TITLE
Upgraded `@ronin/casper` package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@react-aria/ssr": "^3.9.4",
     "@react-aria/textfield": "^3.14.5",
     "@react-email/components": "0.0.18",
-    "@ronin/casper": "0.0.0-3431309115986",
+    "@ronin/casper": "0.0.0-3433555985967",
     "@t3-oss/env-nextjs": "^0.9.2",
     "@tailwindcss/typography": "^0.5.13",
     "@tanstack/react-query": "^5.37.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 0.0.18
         version: 0.0.18(@types/react@18.3.3)(react@18.3.1)
       '@ronin/casper':
-        specifier: 0.0.0-3431309115986
-        version: 0.0.0-3431309115986
+        specifier: 0.0.0-3433555985967
+        version: 0.0.0-3433555985967
       '@t3-oss/env-nextjs':
         specifier: ^0.9.2
         version: 0.9.2(typescript@5.4.5)(zod@3.23.8)
@@ -1349,8 +1349,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
 
-  '@ronin/casper@0.0.0-3431309115986':
-    resolution: {tarball: https://ronin.supply/@ronin/casper/-/casper-0.0.0-3431309115986.tar.gz}
+  '@ronin/casper@0.0.0-3433555985967':
+    resolution: {integrity: sha512-Zgdqcurt1FoJ3n0vmSxIHPCAI6a4C5iirYDsu2jJkYRsC7yvj57LrmlzlzVbhFYyMt/ns7Km2FDJMNISM3sO6g==, tarball: https://ronin.supply/@ronin/casper/0.0.0-3433555985967}
 
   '@rushstack/eslint-patch@1.3.3':
     resolution: {integrity: sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw==}
@@ -5850,7 +5850,7 @@ snapshots:
       '@react-types/shared': 3.23.1(react@18.3.1)
       react: 18.3.1
 
-  '@ronin/casper@0.0.0-3431309115986': {}
+  '@ronin/casper@0.0.0-3433555985967': {}
 
   '@rushstack/eslint-patch@1.3.3': {}
 


### PR DESCRIPTION
As a result of improvements made to how RONIN provides automatic types, the auto-generated package lockfiles are also a bit cleaner now. This change right here upgrades your automatic types to the latest version and applies the cleaner lockfile.